### PR TITLE
Add a karma command

### DIFF
--- a/commands/karma.py
+++ b/commands/karma.py
@@ -9,6 +9,7 @@ from commands import command
 import re
 
 class Karma():
+    '''TODO(14flash): Add description.'''
     # karma is static, so this basically works like a singleton
     karma = dict()
     
@@ -21,6 +22,23 @@ class Karma():
     
     def get_karma(entity):
         return Karma.karma.get(entity, 0)
+        
+    # Why is it called slice? Because I'm too used to golang.
+    def get_sorted_slice(num, key):
+        '''(func, int) -> list
+        Returns a sorted list of the top num entities in the karma dict
+        sorted by the key func.
+        
+        key is function that takes one value and returns a sortable value.'''
+        if num <= 0:
+            return list()
+        return sorted(Karma.karma, key=key)[:num]
+    
+    def get_top(num):
+        return Karma.get_sorted_slice(num, lambda x: -Karma.get_karma(x))
+    
+    def get_bottom(num):
+        return Karma.get_sorted_slice(num, lambda x: Karma.get_karma(x))
 
 class KarmaAdderCommand(command.Command):
     '''KarmaAdderCommand finds ++ and -- messages and adjusts the karma
@@ -48,24 +66,62 @@ class KarmaAdderCommand(command.Command):
         # great C++ is without the bot going crazy.
         return re.findall(r'(\w{2,})(\+\+|--)', message.content, re.I)
 
-class KarmaCountCommand(command.DirectOnlyCommand):
+class KarmaValueCommand(command.DirectOnlyCommand):
     '''KarmaCountCommand responds to direct queries about an entity's karma.'''
+    
+    TOP_MIN = 1
+    TOP_MAX = 10
+    TOP_DEF = 5
     
     def matches(self, message):
         return self.collect_args(message)
     
     def action(self, message, send_func):
+        send_wrapper = lambda text: send_func(message.channel, text)
         args_match = self.collect_args(message)
         if args_match.group(1) == 'count':
-            entity = args_match.group(2)
-            amount = Karma.get_karma(entity)
-            yield from send_func(message.channel, '%s has %s karma' % (entity, amount))
+            yield from self.count(args_match.group(2), send_wrapper)
         elif args_match.group(1) == 'top':
-            yield from send_func(message.channel, 'Not yet implemented.')
+            yield from self.top(args_match.group(2), send_wrapper)
         elif args_match.group(1) == 'bottom':
-            yield from send_func(message.channel, 'Not yet implemented.')
+            yield from self.bottom(args_match.group(2), send_wrapper)
     
     def collect_args(self, message):
         # would it be better to just have group 2 be a .* catch all and have
         # each command do a smaller regex?
-        return re.search(r'\bkarma\s(count|top|bottom)\b\s?(\w+)?', message.content, re.I)
+        return re.search(r'\bkarma\s(count|top|bottom)\b\s?(\w*)', message.content, re.I)
+    
+    def count(self, entity, send_func):
+        if not entity:
+            yield from send_func('What do you want me to count silly human?')
+        else:
+            amount = Karma.get_karma(entity)
+            yield from send_func('%s has %d karma' % (entity, amount))
+    
+    def top(self, entity, send_func):
+        num = self.parse_and_validate_number(entity)
+        entities = Karma.get_top(num)
+        yield from send_func('The top %d karma holders are:' % num)
+        for entity in entities:
+            yield from send_func('%s: %d' % (entity, Karma.get_karma(entity)))
+    
+    def bottom(self, entity, send_func):
+        num = self.parse_and_validate_number(entity)
+        entities = Karma.get_bottom(num)
+        yield from send_func('The bottom %d karma holders are:' % num)
+        for entity in entities:
+            yield from send_func('%s: %d' % (entity, Karma.get_karma(entity)))
+    
+    def parse_and_validate_number(self, num_string):
+        if not num_string:
+            num = KarmaValueCommand.TOP_DEF
+        else:
+            try:
+                num = int(num_string)
+            except ValueError:
+                num = KarmaValueCommand.TOP_DEF
+        if num < KarmaValueCommand.TOP_MIN:
+            num = KarmaValueCommand.TOP_MIN
+        if num > KarmaValueCommand.TOP_MAX:
+            num = KarmaValueCommand.TOP_MAX
+        return num

--- a/commands/karma.py
+++ b/commands/karma.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Sun Jan 14 19:52:01 2018
+
+@author: 14flash
+"""
+
+from commands import command
+import re
+
+class Karma():
+    # karma is static, so this basically works like a singleton
+    karma = dict()
+    
+    def add_karma(entity, amount):
+        try:
+            Karma.karma[entity] += amount
+        except KeyError:
+            Karma.karma[entity] = amount
+        return Karma.karma[entity]
+    
+    def get_karma(entity):
+        return Karma.karma.get(entity, 0)
+
+class KarmaAdderCommand(command.Command):
+    '''KarmaAdderCommand finds ++ and -- messages and adjusts the karma
+    appropriately.'''
+    
+    def matches(self, message):
+        return len(self.collect_args(message)) > 0
+    
+    def action(self, message, send_func):
+        args_match = self.collect_args(message)
+        for args in args_match:
+            entity = args[0]
+            if args[1] == '++':
+                amount = 1
+                karma_message = '%s rocks! (karma: %d)'
+            else:
+                amount = -1
+                karma_message = '%s sucks! (karma: %d)'
+            new_amount = Karma.add_karma(entity, amount)
+            yield from send_func(message.channel, karma_message % (entity, new_amount))
+            
+    
+    def collect_args(self, message):
+        # An enitity must be more than 1 character so I can tlak about how
+        # great C++ is without the bot going crazy.
+        return re.findall(r'(\w{2,})(\+\+|--)', message.content, re.I)
+
+class KarmaCountCommand(command.DirectOnlyCommand):
+    '''KarmaCountCommand responds to direct queries about an entity's karma.'''
+    
+    def matches(self, message):
+        return self.collect_args(message)
+    
+    def action(self, message, send_func):
+        args_match = self.collect_args(message)
+        if args_match.group(1) == 'count':
+            entity = args_match.group(2)
+            amount = Karma.get_karma(entity)
+            yield from send_func(message.channel, '%s has %s karma' % (entity, amount))
+        elif args_match.group(1) == 'top':
+            yield from send_func(message.channel, 'Not yet implemented.')
+        elif args_match.group(1) == 'bottom':
+            yield from send_func(message.channel, 'Not yet implemented.')
+    
+    def collect_args(self, message):
+        # would it be better to just have group 2 be a .* catch all and have
+        # each command do a smaller regex?
+        return re.search(r'\bkarma\s(count|top|bottom)\b\s?(\w+)?', message.content, re.I)

--- a/commands/karma.py
+++ b/commands/karma.py
@@ -6,14 +6,18 @@ Created on Sun Jan 14 19:52:01 2018
 """
 
 from commands import command
+import random
 import re
 
 class Karma():
-    '''TODO(14flash): Add description.'''
+    '''Karma holds the dictionary of entity karma, and utils for editting it
+    easily.'''
     # karma is static, so this basically works like a singleton
     karma = dict()
     
     def add_karma(entity, amount):
+        '''(str, int) -> int
+        Gives amount karma to entity, and returns how much karma entity now has.'''
         try:
             Karma.karma[entity] += amount
         except KeyError:
@@ -21,11 +25,13 @@ class Karma():
         return Karma.karma[entity]
     
     def get_karma(entity):
+        '''(str) -> int
+        Returns how much karma entity has.'''
         return Karma.karma.get(entity, 0)
         
     # Why is it called slice? Because I'm too used to golang.
     def get_sorted_slice(num, key):
-        '''(func, int) -> list
+        '''(int, func) -> list
         Returns a sorted list of the top num entities in the karma dict
         sorted by the key func.
         
@@ -35,14 +41,25 @@ class Karma():
         return sorted(Karma.karma, key=key)[:num]
     
     def get_top(num):
+        '''(int) -> list
+        Returns a list of the top num karma holders (or less than that if there
+        are less than num total karma holders.)'''
         return Karma.get_sorted_slice(num, lambda x: -Karma.get_karma(x))
     
     def get_bottom(num):
+        '''(int) -> list
+        Returns a list of the bottom num karma holders (or less than that if
+        there are less than num total karma holders.)'''
         return Karma.get_sorted_slice(num, lambda x: Karma.get_karma(x))
 
 class KarmaAdderCommand(command.Command):
     '''KarmaAdderCommand finds ++ and -- messages and adjusts the karma
     appropriately.'''
+    
+    def __init__(self, karma_up_data, karma_down_data, **kwargs):
+        super().__init__(**kwargs)
+        self.karma_up_data = karma_up_data.content
+        self.karma_down_data = karma_down_data.content
     
     def matches(self, message):
         return len(self.collect_args(message)) > 0
@@ -53,10 +70,12 @@ class KarmaAdderCommand(command.Command):
             entity = args[0]
             if args[1] == '++':
                 amount = 1
-                karma_message = '%s rocks! (karma: %d)'
+                base_message = random.choice(self.karma_up_data)
+                karma_message = base_message + ' (karma: %d)'
             else:
                 amount = -1
-                karma_message = '%s sucks! (karma: %d)'
+                base_message = random.choice(self.karma_down_data)
+                karma_message = base_message + ' (karma: %d)'
             new_amount = Karma.add_karma(entity, amount)
             yield from send_func(message.channel, karma_message % (entity, new_amount))
             
@@ -98,15 +117,15 @@ class KarmaValueCommand(command.DirectOnlyCommand):
             amount = Karma.get_karma(entity)
             yield from send_func('%s has %d karma' % (entity, amount))
     
-    def top(self, entity, send_func):
-        num = self.parse_and_validate_number(entity)
+    def top(self, num, send_func):
+        num = self.parse_and_validate_number(num)
         entities = Karma.get_top(num)
         yield from send_func('The top %d karma holders are:' % num)
         for entity in entities:
             yield from send_func('%s: %d' % (entity, Karma.get_karma(entity)))
     
-    def bottom(self, entity, send_func):
-        num = self.parse_and_validate_number(entity)
+    def bottom(self, num, send_func):
+        num = self.parse_and_validate_number(num)
         entities = Karma.get_bottom(num)
         yield from send_func('The bottom %d karma holders are:' % num)
         for entity in entities:

--- a/data/config.config
+++ b/data/config.config
@@ -4,5 +4,7 @@ channelsloc = ./data/channels.config
 snarkloc = ./data/snark.txt
 permissionsloc = ./data/permissions.config
 forumdiscorduserloc = ./data/freeforum-discorduser.config
+karmauploc = ./data/karmaup.txt
+karmadownloc = ./data/karmadown.txt
 forumpostemoji = 🥔
 invalidmessagemessage = I'm sorry, did you say `KILL ALL HUMANS`?

--- a/data/karmadown.txt
+++ b/data/karmadown.txt
@@ -1,0 +1,4 @@
+%s sucks!
+%s whited out!
+%s got pwned!
+%s lost a life!

--- a/data/karmaup.txt
+++ b/data/karmaup.txt
@@ -1,0 +1,7 @@
+%s rocks!
+%s leveled up!
+%s deserves a high five!
+%s is a beast!
+All hail %s!
+%s got a 1-up!
+It's a bird! It's a plane! No, it's %s!

--- a/main.py
+++ b/main.py
@@ -12,6 +12,7 @@ from commands import shutdown
 from commands import urladder
 from commands import forumpost
 from commands import invalid
+from commands import karma
 
 sys.path.append('./libs')
 from libs import configloader, scraperff, dataloader, scrapert, scraperred
@@ -128,6 +129,8 @@ if __name__ == '__main__':
     bot.register_command(blamejosh.BlameJoshCommand())
     emoji = config.content["forumpostemoji"]
     bot.register_command(forumpost.ForumPostCommand(add_reaction_func=bot.add_reaction, emoji=emoji))
+    bot.register_command(karma.KarmaAdderCommand())
+    bot.register_command(karma.KarmaCountCommand(user=user_func))
 
     qForum = Queue()
     qTwitter = Queue()

--- a/main.py
+++ b/main.py
@@ -129,7 +129,9 @@ if __name__ == '__main__':
     bot.register_command(blamejosh.BlameJoshCommand())
     emoji = config.content["forumpostemoji"]
     bot.register_command(forumpost.ForumPostCommand(add_reaction_func=bot.add_reaction, emoji=emoji))
-    bot.register_command(karma.KarmaAdderCommand())
+    karma_up_data = dataloader.datafile(config.content["karmauploc"])
+    karma_down_data = dataloader.datafile(config.content["karmadownloc"])
+    bot.register_command(karma.KarmaAdderCommand(karma_up_data=karma_up_data, karma_down_data=karma_down_data))
     bot.register_command(karma.KarmaValueCommand(user=user_func))
 
     qForum = Queue()

--- a/main.py
+++ b/main.py
@@ -130,7 +130,7 @@ if __name__ == '__main__':
     emoji = config.content["forumpostemoji"]
     bot.register_command(forumpost.ForumPostCommand(add_reaction_func=bot.add_reaction, emoji=emoji))
     bot.register_command(karma.KarmaAdderCommand())
-    bot.register_command(karma.KarmaCountCommand(user=user_func))
+    bot.register_command(karma.KarmaValueCommand(user=user_func))
 
     qForum = Queue()
     qTwitter = Queue()

--- a/main.py
+++ b/main.py
@@ -159,6 +159,11 @@ if __name__ == '__main__':
     #run until logged out
     loop.run_until_complete(bot.connect())    
 
+    karma_entity_sum = 0
+    for key in karma.Karma.karma:
+        karma_entity_sum += len(key)
+    log.info("karma would take about %d bytes to save" % karma_entity_sum)
+
     stop.put("STAHHHHP")
     twitterScraper.join()
     forumScraper.join()


### PR DESCRIPTION
Give things karma with ++ or take karma away with --.  You can see a thing's karma with 'karma count <thing>'.  You can see the top karma holders with 'karma top [n]'.  You can see the bottom karma holders with karma bottom [n]'. n is limited to be between 1 and 10 in both cases.

Karma is not saved across runs of the bot.  This is intentional because I don't know how much space it will take after users have been using it for a while.  If the bot shuts down properly, it will log an estimate of how many bytes it takes to save the karma map.

Known Issues:
 - You cannot count how much karma "snark" has.  (Snark command takes precedence over karma command).