### PR TITLE
Add MBC Tie breakers to STV votes

### DIFF
--- a/libs/voting.py
+++ b/libs/voting.py
@@ -50,8 +50,8 @@ class FPTP(Poll):
 
     def dumpVotes(self):
         '''(FPTP) -> list
-        returns a list of [option, total votes], unsorted'''
-        return [[self.votes[x],x] for x in self.votes] #turn self.votes dict into list of [votes, options]
+        returns a list of [option, voter], unsorted'''
+        return [[self.votes[x],x] for x in self.votes] #turn self.votes dict into list of [votes, voter]
 
 class STV(Poll):
     '''Implementation of Single Transferable Vote voting system'''
@@ -61,7 +61,7 @@ class STV(Poll):
         ie transferables=2 means a voter can have a first choice and a second choice
         transferables=5 means a voter can have a first choice up to a fifth choice'''
         super().__init__(options=options, allowed_voters=allowed_voters, **kwargs)
-        if transferables!=None:
+        if transferables is not None and isinstance(transferables, int):
             self.transferables = transferables
         else:
             self.transferables = len(self.options)
@@ -77,7 +77,7 @@ class STV(Poll):
             for i in vote:
                 if i not in self.options:
                     raise ValueError("Invalid option: "+i)
-                if self.options.count(i)>1:
+                if vote.count(i)>1:
                     raise ValueError("Option "+i+" used more than once")
             self.votes[str(voter)]=list(vote)
             self.voted.append(str(voter))

--- a/libs/voting.py
+++ b/libs/voting.py
@@ -1,7 +1,11 @@
 class Poll():
     '''Base class for voting systems that everything below extends
     This class should never be used in a concrete implementation'''
-    def __init__(self, options = ["Y", "N"], allowed_voters = None, voted=list(), votes=dict()):
+    def __init__(self, options = ["Y", "N"], allowed_voters = None, voted=None, votes=None):
+        if voted is None:
+            voted = list()
+        if votes is None:
+            votes = dict()
         self.options = options
         self.allowed_voters = allowed_voters
         self.voted = voted

--- a/libs/voting_test.py
+++ b/libs/voting_test.py
@@ -1,0 +1,67 @@
+# -*- coding: utf-8 -*-
+"""
+Created on Wed Jul 18 07:58:54 2018
+
+@author: 14flash
+"""
+
+import unittest
+from libs import voting
+
+class TestPoll(unittest.TestCase):
+    
+    def test_pollAllowsAllVoters(self):
+        poll = voting.Poll(allowed_voters=None)
+        
+        self.assertTrue(poll.addVote('john', 'Y'))
+        self.assertIn('john', poll.voted)
+        self.assertEqual('Y', poll.votes['john'])
+    
+    def test_pollDeniesVoters(self):
+        poll = voting.Poll(allowed_voters=['john', 'hank'])
+        
+        self.assertFalse(poll.addVote('mike', 'N'))
+        self.assertNotIn('mike', poll.voted)
+        self.assertNotIn('mike', poll.votes)
+        
+        self.assertTrue(poll.addVote('john', 'Y'))
+        self.assertIn('john', poll.voted)
+        self.assertEqual('Y', poll.votes['john'])
+    
+    def test_pollAcceptsOptions(self):
+        poll = voting.Poll(options=['yes', 'maybe', 'no'])
+        
+        self.assertTrue(poll.addVote('john', 'maybe'))
+        self.assertIn('john', poll.voted)
+        self.assertEqual('maybe', poll.votes['john'])
+    
+    def test_pollDeniesOptions(self):
+        poll = voting.Poll(options=['yes', 'maybe', 'no'])
+        
+        self.assertFalse(poll.addVote('john', 'Y'))
+        self.assertNotIn('john', poll.voted)
+        self.assertNotIn('john', poll.votes)
+        
+    def test_pollCannotVoteTwice(self):
+        poll = voting.Poll()
+        
+        self.assertTrue(poll.addVote('john', 'Y'))
+        self.assertIn('john', poll.voted)
+        self.assertEqual('Y', poll.votes['john'])
+        
+        self.assertFalse(poll.addVote('john', 'N'))
+        self.assertIn('john', poll.voted)
+        self.assertEqual('Y', poll.votes['john'])
+        
+    # I'm only doing a basic test of addChoice because it points to addVote.
+    # This test should cover the case where it is removed, but not behavioral
+    # if it changes.
+    def test_pollAddChoice(self):
+        poll = voting.Poll()
+        
+        self.assertTrue(poll.addChoice('john', 'Y'))
+        self.assertIn('john', poll.voted)
+        self.assertEqual('Y', poll.votes['john'])
+    
+if __name__ == '__main__':
+    unittest.main()

--- a/libs/voting_test.py
+++ b/libs/voting_test.py
@@ -62,6 +62,149 @@ class TestPoll(unittest.TestCase):
         self.assertTrue(poll.addChoice('john', 'Y'))
         self.assertIn('john', poll.voted)
         self.assertEqual('Y', poll.votes['john'])
+
+class TestFPTP(unittest.TestCase):
+    
+    # Order may change. For now there is a guaranteed order.
+    def test_tallyVotesNoVotes(self):
+        poll = voting.FPTP()
+        tally = poll.tallyVotes()
+        
+        self.assertEqual('Y', tally[0][0])
+        self.assertEqual(0, tally[0][1])
+        self.assertEqual('N', tally[1][0])
+        self.assertEqual(0, tally[1][1])
+        
+    def test_tallyVotesWinnerFirst(self):
+        poll = voting.FPTP()
+        poll.addVote('john', 'N')
+        tally = poll.tallyVotes()
+        
+        self.assertEqual('N', tally[0][0])
+        self.assertEqual(1, tally[0][1])
+    
+    def test_tallyVotesSameLengthAsOptions(self):
+        opt = ['a', 'b', 'c', 'd']
+        poll = voting.FPTP(options=opt)
+        tally = poll.tallyVotes()
+        
+        self.assertEqual(len(opt), len(tally))
+
+class TestSTV(unittest.TestCase):
+    
+    def test_STVAutoSetTransferables(self):
+        poll = voting.STV(options=['yes', 'maybe', 'no'])
+        self.assertEqual(3, poll.transferables)
+    
+    def test_STVSetTransferables(self):
+        poll = voting.STV(transferables=5)
+        self.assertEqual(5, poll.transferables)
+    
+    def test_STVTransferablesTypeCheck(self):
+        poll = voting.STV(options=['A', 'B', 'C'], transferables="three")
+        self.assertEqual(3, poll.transferables)
+    
+    def test_addVoteWrongLengthRaisesError(self):
+        poll = voting.STV(transferables=2)
+        self.assertRaises(ValueError, poll.addVote, 'john', ['A'])
+    
+    def test_addVoteVoterNotAllowedRaisesError(self):
+        poll = voting.STV(allowed_voters=['john', 'hank'])
+        self.assertRaises(ValueError, poll.addVote, 'mike', ['C', 'B', 'A'])
+    
+    def test_addVoteDuplicateVoteRaisesError(self):
+        poll = voting.STV()
+        self.assertRaises(ValueError, poll.addVote, 'john', ['A', 'B', 'A'])
+    
+    def test_addVoteInvalidOptionRaisesError(self):
+        poll = voting.STV()
+        self.assertRaises(ValueError, poll.addVote, 'john', ['A', 'B', 'not-a-choice'])
+    
+    def test_addVoteVotingAgainRaissesError(self):
+        poll = voting.STV()
+        poll.addVote('john', ['A', 'B', 'C'])
+        self.assertRaises(ValueError, poll.addVote, 'john', ['B', 'A', 'C'])
+    
+    def test_addVoteSavesVote(self):
+        poll = voting.STV()
+        poll.addVote('john', ['A', 'B', 'C'])
+        self.assertIn('john', poll.voted)
+        self.assertEqual(['A', 'B', 'C'], poll.votes['john'])
+    
+    def test_addChoiceVoterNotAllowed(self):
+        poll = voting.STV(allowed_voters=['john', 'hank'])
+        self.assertFalse(poll.addChoice('mike', 'A'))
+        self.assertNotIn('mike', poll.voted)
+        self.assertNotIn('mike', poll.votes)
+    
+    def test_addChoiceAddFirst(self):
+        poll = voting.STV()
+        self.assertTrue(poll.addChoice('john', 'A'))
+        self.assertIn('john', poll.voted)
+        self.assertEqual(['A', None, None], poll.votes['john'])
+    
+    def test_addChoiceAddDuplicateNotAllowed(self):
+        poll = voting.STV()
+        poll.addChoice('john', 'A')
+        self.assertFalse(poll.addChoice('john', 'A'))
+        self.assertEqual(['A', None, None], poll.votes['john'])
+    
+    def test_addChoiceNoMoreThanTransferablesAllowed(self):
+        poll = voting.STV(transferables=1)
+        poll.addChoice('john', 'A')
+        self.assertFalse(poll.addChoice('john', 'B'))
+        self.assertEqual(['A'], poll.votes['john'])
+    
+    # This doesn't exactly match my expectation for the API, but oh well,
+    # documenting it is good.
+    def test_addChoiceInvalidOptionNotAllowed(self):
+        poll = voting.STV()
+        self.assertFalse(poll.addChoice('john', None))
+        self.assertIn('john', poll.voted)
+        self.assertEqual([None, None, None], poll.votes['john'])
+    
+    def test_tallyVotesNoOptionsNoVotes(self):
+        poll = voting.STV(options=[])
+        tally = poll.tallyVotes()
+        self.assertEqual(['No votes recorded'], tally)
+    
+    # Order may be changed on this test.  For now, there is a guaranteed order.
+    def test_tallyVotesNoVotesNoTieBreaks(self):
+        poll = voting.STV()
+        tally = poll.tallyVotes()
+        self.assertEqual(len(tally), len(poll.options))
+        self.assertEqual(['C', 0], tally[0])
+        self.assertEqual(['B', 0], tally[1])
+        self.assertEqual(['A', 0], tally[2])
+    
+    # I, once again, don't understand the meaning of the vote count in this api
+    # so I'm documenting it with unit tests rather than trying to change it.
+    def test_tallyVotesClearWinner(self):
+        poll = voting.STV()
+        poll.addVote('john', ['A', 'B', 'C'])
+        poll.addVote('hank', ['B', 'A', 'C'])
+        poll.addVote('mike', ['A', 'C', 'B'])
+        tally = poll.tallyVotes()
+        self.assertEqual(['A', 3], tally[0])
+        self.assertEqual(['B', 1], tally[1])
+        self.assertEqual(['C', 0], tally[2])
+    
+    # This test should fail unitl MBC tie-breaking is written into the bot
+    def test_tallyVotesTieBroken(self):
+        poll = voting.STV(options=['a', 'b', 'c', 'd'])
+        # I really want to clean up addVote's API just to make this unit test cleaner to setup...
+        poll.addChoice('john', 'a')
+        poll.addChoice('hank', 'b')
+        poll.addChoice('hank', 'c')
+        poll.addChoice('hank', 'a')
+        poll.addChoice('mike', 'a')
+        poll.addChoice('mike', 'd')
+        poll.addVote('olly', ['b', 'd', 'a', 'c'])
+        # At this point, 'a' and 'b' are tied for most votes, but MBC('a') = 6,
+        # MBC('b') = 7 so 'b' should always be top of the list
+        tally = poll.tallyVotes()
+        self.assertEqual(['b', 2], tally[0])
+        self.assertEqual(['a', 3], tally[1])
     
 if __name__ == '__main__':
     unittest.main()

--- a/libs/voting_test.py
+++ b/libs/voting_test.py
@@ -204,7 +204,46 @@ class TestSTV(unittest.TestCase):
         # MBC('b') = 7 so 'b' should always be top of the list
         tally = poll.tallyVotes()
         self.assertEqual(['b', 2], tally[0])
-        self.assertEqual(['a', 3], tally[1])
+        self.assertEqual(['a', 2], tally[1])
+    
+    def test_tallyVotesFromTwoPolls(self):
+        #This is a test I'd like to do because I suspect options can get overwritten and then default options dies        
+        pass
+    
+    def test_bordaCountOptionNotIncluded(self):
+        poll = voting.STV()
+        self.assertEqual(0, poll._bordaCountFromSingleBallot(['a'], 'b'))
+    
+    def test_bordaCountLastOptionReturnsOne(self):
+        poll = voting.STV()
+        self.assertEqual(1, poll._bordaCountFromSingleBallot(['a', 'b', 'c'], 'c'))
+    
+    def test_bordaCountMiddleOptions(self):
+        poll = voting.STV()
+        self.assertEqual(2, poll._bordaCountFromSingleBallot(['a', 'b', 'c'], 'b'))
+    
+    def test_bordaCountFirstOptionReturnsMaxNumber(self):
+        poll = voting.STV()
+        self.assertEqual(3, poll._bordaCountFromSingleBallot(['a', 'b', 'c'], 'a'))
+    
+    def test_bordaCountDoesNotCountNones(self):
+        poll = voting.STV()
+        self.assertEqual(1, poll._bordaCountFromSingleBallot(['a', None, None, None], 'a'))
+    
+    def test_setMBC(self):
+        poll = voting.STV(options=['b', 'd', 'a', 'c'])
+        poll.addChoice('john', 'a')
+        poll.addChoice('hank', 'b')
+        poll.addChoice('hank', 'c')
+        poll.addChoice('hank', 'a')
+        poll.addChoice('mike', 'a')
+        poll.addChoice('mike', 'd')
+        poll.addVote('olly', ['b', 'd', 'a', 'c'])
+        poll.setModifiedBordaCounts()
+        self.assertEqual(6, poll.MBC['a'])
+        self.assertEqual(7, poll.MBC['b'])
+        self.assertEqual(3, poll.MBC['c'])
+        self.assertEqual(4, poll.MBC['d'])
     
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Also add unit tests to voting.py to make sure nothing else broke as a result of these changes.

The unit tests caught a few bugs which are also fixed in this PR.  First, multiple polls couldn't be instantiated without specifying `votes` and `voted` in the constructor.  Second, if a ballot with more than one vote for a candidate was passed to `addVote` it would still accept it.

This does not handle the case where there's a tie after MBC is taken into account, which should be done by a random coin flip and which I'll probably do in a follow-up PR along with other QoL improvements.